### PR TITLE
Update Requirements for python3.7<=

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ scikit-learn==0.24.1
 gensim==3.8.3
 matplotlib==3.3.4
 black==19.10b0
-dataclasses==0.8
 ray==1.2.0
 aioredis<2
 ray[tune]


### PR DESCRIPTION
Dataclasses is now part of python 3.7 <=.
I did not also find dataclasses used in the repo,
so I removed it from the requirements so we are able to install
the package, otherwise pip will fail. 